### PR TITLE
Update convert_stix.py to include cache_clear()

### DIFF
--- a/stix2slider/convert_stix.py
+++ b/stix2slider/convert_stix.py
@@ -1,7 +1,7 @@
 import uuid
 
-import stixmarx
 import cybox.utils.caches
+import stixmarx
 from cybox.core import Observable
 from six import text_type
 from stix2slider.convert_cyber_observables import convert_cyber_observables

--- a/stix2slider/convert_stix.py
+++ b/stix2slider/convert_stix.py
@@ -1,6 +1,7 @@
 import uuid
 
 import stixmarx
+import cybox.utils.caches
 from cybox.core import Observable
 from six import text_type
 from stix2slider.convert_cyber_observables import convert_cyber_observables
@@ -1019,6 +1020,8 @@ def convert_bundle(bundle_obj):
     _EXPLICIT_OBJECT_USED = {}
     _VICTIM_TARGET_TTPS = []
     _KILL_CHAINS = {}
+
+    cybox.utils.caches.cache_clear()
 
     CONTAINER = stixmarx.new()
     pkg = CONTAINER.package


### PR DESCRIPTION
Add cybox.utils.caches.cache_clear() to prevent RAM consumption issue.