### PR TITLE
STIX 1.1.1 support

### DIFF
--- a/docs/slider_log_messages.rst
+++ b/docs/slider_log_messages.rst
@@ -63,7 +63,7 @@ Multiple File Extensions in *[id]* not supported yet                            
 ``account_type`` property of *[id]* in STIX 2.x is not directly represented as a property in STIX 1.x                        506     Warn
 Received Line *[line]* in *[id]* has a prefix that is not representable in STIX 1.x                                          507     Warn
 Unable to convert STIX 2.x sighting *[id]* because it doesn't refer to an indicator                                          508     Warn
-``NO MESSAGE ASSIGNED``                                                                                                      509
+Ignoring *[id]*, because a *[type]* cannot be represented in STIX 1.1.1                                                      509     Warn
 Identity has no property to store ``external-references`` from *[id]*                                                        510     Warn
 pe_type SYS in *[id]* is valid in STIX 2.x, but not in STIX 1.x                                                              511     Warn
 pe_type [pe_type] in *[id]* is allowed in STIX 2.x, but not in STIX 1.x                                                      512     Warn
@@ -114,4 +114,3 @@ Assuming imcp packet in *[id]* is v4                                            
 ``InformationSource`` descriptions order or content in may not correspond to the references in *[id]*               702     Info
 *[ref_id]* in *[id]* is not explicitly a member of a STIX 1.x report                                                703     Info
 =================================================================================================================== ====    =====
-

--- a/stix2slider/convert_stix.py
+++ b/stix2slider/convert_stix.py
@@ -389,10 +389,7 @@ def add_missing_property_to_description(obj1x, property_name, property_value):
         if _STIX_1_VERSION == "1.2":
             obj1x.add_description(property_name + ": " + text_type(property_value))
         else:
-            try:
-                obj1x.description = property_name + ": " + text_type(property_value)     
-            except ImmutableError:
-                pass
+            obj1x.description = property_name + ": " + text_type(property_value)     
 
 
 def add_missing_list_property_to_description(obj1x, property_name, property_values):
@@ -400,10 +397,7 @@ def add_missing_list_property_to_description(obj1x, property_name, property_valu
         if _STIX_1_VERSION == "1.2":
             obj1x.add_description(property_name + ": " + ", ".join(property_values))
         else:
-            try:
-                obj1x.description = property_name + ": " + ", ".join(property_values)
-            except ImmutableError:
-                pass
+            obj1x.description = property_name + ": " + ", ".join(property_values)
             
 
 _KILL_CHAINS = {}
@@ -554,7 +548,7 @@ def convert_identity(ident2x):
             if "roles" in ident2x:
                 ident1x.roles = ident2x["roles"]
             if "labels" in ident2x:
-                add_missing_list_property_to_description(ident2x, "labels", ident2x["labels"])
+                add_missing_list_property_to_description(ident1x, "labels", ident2x["labels"])
         if ("sectors" in ident2x or
                 "contact_information" in ident2x or
                 "identity_class" in ident2x or
@@ -620,7 +614,7 @@ def convert_indicator(indicator2x):
         indicator1x.indicator_types = convert_open_vocabs_to_controlled_vocabs(indicator2x["indicator_types"],
                                                                                INDICATOR_LABEL_MAP)
         if "labels" in indicator2x:
-            add_missing_list_property_to_description(indicator2x, "labels", indicator2x["labels"])
+            add_missing_list_property_to_description(indicator1x, "labels", indicator2x["labels"])
     indicator1x.add_valid_time_position(
         convert_to_valid_time(text_type(indicator2x["valid_from"]),
                               text_type(indicator2x["valid_until"]) if "valid_until" in indicator2x else None))
@@ -653,7 +647,7 @@ def convert_malware(malware2x):
     else:
         types = convert_open_vocabs_to_controlled_vocabs(malware2x["malware_types"], MALWARE_LABELS_MAP)
         if "labels" in malware2x:
-            add_missing_list_property_to_description(malware2x, "labels", malware2x["labels"])
+            add_missing_list_property_to_description(malware1x, "labels", malware2x["labels"])
     for t in types:
         malware1x.add_type(t)
     ttp = TTP(id_=convert_id2x(malware2x["id"]),
@@ -753,7 +747,7 @@ def convert_threat_actor(ta2x):
     else:
         types = convert_open_vocabs_to_controlled_vocabs(ta2x["threat_actor_types"], THREAT_ACTOR_LABEL_MAP)
         if "labels" in ta2x:
-            add_missing_list_property_to_description(ta2x, "labels", ta2x["labels"])
+            add_missing_list_property_to_description(ta1x, "labels", ta2x["labels"])
     for t in types:
         ta1x.add_type(t)
     if "description" in ta2x:

--- a/stix2slider/convert_stix.py
+++ b/stix2slider/convert_stix.py
@@ -389,9 +389,11 @@ def add_missing_property_to_description(obj1x, property_name, property_value):
 
 
 def add_missing_list_property_to_description(obj1x, property_name, property_values):
-    if not get_option_value("no_squirrel_gaps"):
-        obj1x.add_description(property_name + ": " + ", ".join(property_values))
-
+    try:
+        if not get_option_value("no_squirrel_gaps"):
+            obj1x.add_description(property_name + ": " + ", ".join(property_values))
+    except AttributeError:
+            warn("Failed to assign %s property of %s object to %s", property_name, obj1x, ", ".join(property_values))
 
 _KILL_CHAINS = {}
 


### PR DESCRIPTION
**Fix for the following problem:**
`python-stix<1.2` doesn't contain a `report` module (https://github.com/STIXProject/python-stix/tree/v1.1.1.13/stix) so import fails at https://github.com/oasis-open/cti-stix-slider/blob/v2.0.0/stix2slider/convert_stix.py#L45
