### PR TITLE
Fix Codecov workflow

### DIFF
--- a/.github/workflows/python-ci-tests.yml
+++ b/.github/workflows/python-ci-tests.yml
@@ -27,7 +27,8 @@ jobs:
       run: |
         tox
     - name: Upload coverage information to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4.3.0
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)


### PR DESCRIPTION
Was failing intermittently as Codecov hit their rate limit; we have to tell it to use our token instead.